### PR TITLE
refactor(BoardListCards): no longer need to set Card's `key` to `idx`…

### DIFF
--- a/src/components/BoardListCards/index.tsx
+++ b/src/components/BoardListCards/index.tsx
@@ -14,11 +14,7 @@ const BoardListCards = ({
       type={DragDropTypes.Row}
     >
       {cards.map(({ id, name }, idx) => (
-        // When moving a card from top to bottom within a scrollable list,
-        // the card is not scrolled into the view when the user has finished
-        // the drag operation. To solve this we use the index of each card
-        // as `key`.
-        <Card key={idx} id={id} name={name} idx={idx} />
+        <Card key={id} id={id} name={name} idx={idx} />
       ))}
     </Droppable>
   );


### PR DESCRIPTION
… to scroll the card into the view after drag n drop